### PR TITLE
Update lesson-13.md

### DIFF
--- a/doc/lesson-13.md
+++ b/doc/lesson-13.md
@@ -221,13 +221,11 @@ Then, we will modify our event listener to use `moreParams` to add or remove the
   methods: {
     //...
     onFilterSet (filterText) {
-        this.moreParams = {
-            'filter': filterText
-        }
+        this.moreParams.filter = filterText
         Vue.nextTick( () => this.$refs.vuetable.refresh())
     },
     onFilterReset () {
-        this.moreParams = {}
+        delete this.moreParams.filter
         Vue.nextTick( () => this.$refs.vuetable.refresh())
     }
   }


### PR DESCRIPTION
keeps the search filter bar from overwriting the whole `moreParams` object

see: https://github.com/ratiw/vuetable-2/issues/20#issuecomment-291380280