### PR TITLE
wrong import path from node module

### DIFF
--- a/src/components/MyVuetable.vue
+++ b/src/components/MyVuetable.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import Vuetable from 'vuetable-2/src/components/Vuetable'
+import Vuetable from 'vuetable-2'
 
 export default {
   components: {


### PR DESCRIPTION
I suppose you have written the code used during development
And please do change it in your wiki docs for the users.
Thank you for the awesome plugin.